### PR TITLE
Add keepStrings parameter to UploadFile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import (
 
 func main() {
 	onesky := onesky.Client{APIKey: "abcdef", Secret: "abcdef", ProjectID: 1}
-	_, err := onesky.UploadFile("messages.yml", "YAML", "en-US")
+	_, err := onesky.UploadFile("messages.yml", "YAML", "en-US", true)
 	if err != nil {
 		fmt.Println("Can not upload file")
 	}
@@ -158,7 +158,7 @@ Downloads translation file from OneSky.
 
 Returns file content via string.
 
-### (c *Client) UploadFile(file, fileFormat, locale string) (UploadData, error)
+### (c *Client) UploadFile(file, fileFormat, locale string, keepStrings bool) (UploadData, error)
 Upload translation file to OneSky.
 * `file` should be a full path to file
 

--- a/onesky.go
+++ b/onesky.go
@@ -317,7 +317,7 @@ func (c *Client) DownloadFile(fileName, locale string) (string, error) {
 }
 
 // UploadFile is method on Client struct which upload file to OneSky service
-func (c *Client) UploadFile(file, fileFormat, locale string) (UploadData, error) {
+func (c *Client) UploadFile(file, fileFormat, locale string, keepStrings bool) (UploadData, error) {
 	endpoint, err := getEndpoint("postFile")
 	if err != nil {
 		return UploadData{}, err
@@ -326,6 +326,11 @@ func (c *Client) UploadFile(file, fileFormat, locale string) (UploadData, error)
 	v := url.Values{}
 	v.Set("locale", locale)
 	v.Set("file_format", fileFormat)
+	if keepStrings {
+		v.Set("is_keeping_all_strings", "true") // default
+	} else {
+		v.Set("is_keeping_all_strings", "false")
+	}
 	urlStr, err := endpoint.full(c, v)
 	if err != nil {
 		return UploadData{}, err

--- a/onesky.go
+++ b/onesky.go
@@ -326,11 +326,7 @@ func (c *Client) UploadFile(file, fileFormat, locale string, keepStrings bool) (
 	v := url.Values{}
 	v.Set("locale", locale)
 	v.Set("file_format", fileFormat)
-	if keepStrings {
-		v.Set("is_keeping_all_strings", "true") // default
-	} else {
-		v.Set("is_keeping_all_strings", "false")
-	}
+	v.Set("is_keeping_all_strings", strconv.FormatBool(keepStrings))
 	urlStr, err := endpoint.full(c, v)
 	if err != nil {
 		return UploadData{}, err


### PR DESCRIPTION
See https://github.com/onesky/api-documentation-platform/blob/master/resources/file.md#upload---upload-a-file for documentation for `is_keeping_all_strings`
